### PR TITLE
Fix ecosystem CI path

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -16,7 +16,7 @@ env:
   # Repo specific setting #
   #########################
 
-  ECOSYSTEM_CI_REPO_PATH: quarkus-java-embedded-framework
+  ECOSYSTEM_CI_REPO_PATH: quarkiverse-jef
 
 jobs:
   build:


### PR DESCRIPTION
I fixed it in the ecosystem CI repo for consistency with the other configurations.

See https://github.com/quarkusio/quarkus-ecosystem-ci/pull/90