### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/linux-native-core/pom.xml
+++ b/linux-native-core/pom.xml
@@ -20,10 +20,6 @@
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/linux-native-core/pom.xml
+++ b/linux-native-core/pom.xml
@@ -21,8 +21,8 @@
             <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145